### PR TITLE
Add initial security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+Thanks for helping make GitHub safe for everyone.
+
+## Security
+
+GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
+
+Even though [open source repositories are outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards, we will ensure that your finding gets passed along to the appropriate maintainers for remediation.
+
+## Reporting Security Issues
+
+If you believe you have found a security vulnerability in any GitHub-owned repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please send an email to opensource-security[@]github.com.
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+- The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Policy
+
+See [GitHub's Safe Harbor Policy](https://docs.github.com/en/site-policy/security-policies/github-bug-bounty-program-legal-safe-harbor)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@ Thanks for helping make GitHub safe for everyone ❤️
 
 ## Security
 
-GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [desktop](https://github.com/desktop).
+GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [GitHub Desktop](https://github.com/desktop).
 
-GitHub Desktop itself is part of [GitHub's bug bounty program](https://bounty.github.com/) and vulnerabilities should be reported there. The Desktop organization on GitHub also contains other open source repositories which may be outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards. Even if that's the case we will ensure that your finding gets passed along to the appropriate maintainers for remediation.
+GitHub Desktop itself is part of [GitHub's bug bounty program](https://bounty.github.com/) and vulnerabilities should be reported there. The GitHub Desktop organization on GitHub also contains other open source repositories which may be [outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards. Even if that's the case we will ensure that your finding gets passed along to the appropriate maintainers for remediation.
 
 ## Reporting Security Issues
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,14 @@
-Thanks for helping make GitHub safe for everyone.
+Thanks for helping make GitHub safe for everyone ❤️
 
 ## Security
 
-GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
+GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [desktop](https://github.com/desktop).
 
-Even though [open source repositories are outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards, we will ensure that your finding gets passed along to the appropriate maintainers for remediation.
+GitHub Desktop itself is part of [GitHub's bug bounty program](https://bounty.github.com/) and vulnerabilities should be reported there. The Desktop organization on GitHub also contains other open source repositories which may be outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards. Even if that's the case we will ensure that your finding gets passed along to the appropriate maintainers for remediation.
 
 ## Reporting Security Issues
+
+If you believe you have found a security vulnerability in the current version of [GitHub Desktop](https://desktop.github.com), please report it to us through our [bug bounty program](https://bounty.github.com/targets/github-desktop.html).
 
 If you believe you have found a security vulnerability in any GitHub-owned repository, please report it to us through coordinated disclosure.
 


### PR DESCRIPTION
This is a mixup of GitHub's [general OSS security policy](https://github.com/github/.github/blob/master/SECURITY.md) and some language specifically about GitHub Desktop and it will apply to all repositories within the @desktop org.